### PR TITLE
Add os with package

### DIFF
--- a/app/controllers/api/packages_controller.rb
+++ b/app/controllers/api/packages_controller.rb
@@ -67,7 +67,12 @@ module Api
         @package = @current_user.packages.build(package_params)
 
         if @package.save
-          render json: @package, status: :created
+          if @package.operating_statements.length == 0
+            @operating_statement = @package.operating_statements.create()
+          else
+            @operating_statement = @package.operating_statements.first
+          end
+          render json: { package: @package, operating_statement: @operating_statement }, status: :created
         else
           render json: @package.errors, status: :unprocessable_entity
         end


### PR DESCRIPTION
If there is no operating statement present, it will be created with the package and returned as JSON, along with the package.